### PR TITLE
solves MaksymBilenko/docker-oracle-12c#1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM sath89/oracle-12c-base
 ### This image is a build from non automated image cause of no possibility of Oracle 12c instalation in Docker container
 
 ENV WEB_CONSOLE true
+ENV DBCA_TOTAL_MEMORY 512
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ case "$1" in
 			echo "Starting tnslsnr"
 			su oracle -c "/u01/app/oracle/product/12.1.0/xe/bin/tnslsnr &"
 			#create DB for SID: xe
-			su oracle -c "$ORACLE_HOME/bin/dbca -silent -createDatabase -templateName General_Purpose.dbc -gdbname xe.oracle.docker -sid xe -responseFile NO_VALUE -characterSet AL32UTF8 -totalMemory 512 -emConfiguration LOCAL -pdbAdminPassword oracle -sysPassword oracle -systemPassword oracle"
+			su oracle -c "$ORACLE_HOME/bin/dbca -silent -createDatabase -templateName General_Purpose.dbc -gdbname xe.oracle.docker -sid xe -responseFile NO_VALUE -characterSet AL32UTF8 -totalMemory $DBCA_TOTAL_MEMORY -emConfiguration LOCAL -pdbAdminPassword oracle -sysPassword oracle -systemPassword oracle"
 			
 			echo "Configuring Apex console"
 			cd $ORACLE_HOME/apex


### PR DESCRIPTION
Using the dbca-command with an ENV variable, you can set it on docker run like
```
docker run -e "DBCA_TOTAL_MEMORY=1024" [...] satth89/oracle-12c [...]
```

solves https://github.com/MaksymBilenko/docker-oracle-12c/issues/1