### PR TITLE
Updated README.md with service name and sqlplus connection example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,15 @@ Connect database with following setting:
     hostname: localhost
     port: 1521
     sid: xe
+    service name: xe.oracle.docker
     username: system
     password: oracle
+
+To connect using sqlplus:
+
+<pre>
+sqlplus system/oracle@//localhost:1521/xe.oracle.docker
+</pre>
 
 Password for SYS & SYSTEM:
 


### PR DESCRIPTION
This pull request is to add the service name and a an example of how to connect using sqlplus to the README. This will definitely remove some friction for casual users of Oracle, who will naturally gravitate towards using this docker image.