### PR TITLE
Allow further configuration for dump import

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ exit;
 EOL
 
 	su oracle -c "NLS_LANG=.$CHARACTER_SET $ORACLE_HOME/bin/sqlplus -S / as sysdba @/tmp/impdp.sql"
-	su oracle -c "NLS_LANG=.$CHARACTER_SET $ORACLE_HOME/bin/impdp IMPDP/IMPDP directory=IMPDP dumpfile=$DUMP_FILE"
+	su oracle -c "NLS_LANG=.$CHARACTER_SET $ORACLE_HOME/bin/impdp IMPDP/IMPDP directory=IMPDP dumpfile=$DUMP_FILE $IMPDP_OPTIONS"
 	#Disable IMPDP user
 	echo -e 'ALTER USER IMPDP ACCOUNT LOCK;\nexit;' | su oracle -c "NLS_LANG=.$CHARACTER_SET $ORACLE_HOME/bin/sqlplus -S / as sysdba"
 	set -e


### PR DESCRIPTION
Many times remap table space is needed on a dump

    REMAP_TABLESPACE=FOO:BAR

I can imagine many other changes that can be useful to tweak. In general, allow to change user, password, schema is a desirable tweak