### PR TITLE
Add environment variable for ownership fix

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-# Prevent owner issues on mounted folders
-chown -R oracle:dba /u01/app/oracle
-chown -R oracle:dba /docker-entrypoint-initdb.d/
+# Prevent owner issues on mounted folders, if desired
+if [ "$ENABLE_OWNERSHIP_FIX" = true ] ; then
+	chown -R oracle:dba /u01/app/oracle
+	chown -R oracle:dba /docker-entrypoint-initdb.d/
+fi
+
 rm -f /u01/app/oracle/product
 ln -s /u01/app/oracle-product /u01/app/oracle/product
 


### PR DESCRIPTION
Modifying volume contents without explicit knowledge of the user can cause severe problems, even if it's only modifying file privileges. Especially for an import directory i would not expect that the script will try to modify any of my files.

If there's really a privilege problem, the user should grant the privileges on the host system, but not the docker image without the acknowledge of the user.

So, if a user really wants the script to update privileges, he should configure it (e.g. with an environment variable, see diff).

Another option (not included in this pull request) could be to give an advice to the user, how to adjust the file privileges/ownership settings if they don't match the requirements.

Best regards
Matthias